### PR TITLE
viz and html updates, agreement code compatibility

### DIFF
--- a/resources/ud/changelog.sh
+++ b/resources/ud/changelog.sh
@@ -1,5 +1,5 @@
 # Rename UD_Norwegian-Bokmaal -> UD_Norwegian_Bokmål-NDT 
-mv ud-treebanks-v2.18/UD_Norwegian-Bokmaal ud-treebanks-v2.18/UD_Norwegian_Bokmål-NDT 
+mv ud-treebanks-v2.18/UD_Norwegian-Bokmaal ud-treebanks-v2.18/UD_Norwegian_Bokmaal-NDT 
 
 # Rename UD_Norwegian-Nynorsk -> UD_Norwegian_Nynorsk-NDT
 mv ud-treebanks-v2.18/UD_Norwegian-Nynorsk ud-treebanks-v2.18/UD_Norwegian_Nynorsk-NDT 

--- a/resources/unimorph/changelog.sh
+++ b/resources/unimorph/changelog.sh
@@ -67,7 +67,7 @@ sed "s/:/;/" hsb/hsb > hsb/hsb2; mv hsb/hsb2 hsb/hsb
 sed "s/:3:/;3;/" hsb/hsb > hsb/hsb2; mv hsb/hsb2 hsb/hsb
 
 # Slovak
-/opt/homebrew/bin/unxz slk/slk.xz slk/slk.xz
+unxz slk/slk.xz slk/slk.xz
 cut -d$'\t' -f 1-3 slk/slk > slk/slk2; mv slk/slk2 slk/slk
 
 # Kazakh
@@ -75,7 +75,6 @@ cat kaz/kaz.sm >> kaz/kaz
 
 # Sanskrit
 sed "s/PRES/PRS/" san/san > san/san2; mv san/san2 san/san
-sed "s/NEU/NEUT/" san/san > san/san2; mv san/san2 san/san
 sed "s/{//g; s/}//g" san/san > san/san2; mv san/san2 san/san
 
 # Dutch
@@ -87,3 +86,6 @@ grep -v ADP deu/deu.segmentations > deu/deu2.segmentations; mv deu/deu2.segmenta
 
 # Kurmanji
 sed "s/1;2;3;/1,2,3;/" kmr/kmr > kmr/kmr2; mv kmr/kmr2 kmr/kmr
+
+# Yiddish
+sed "s/PRES/PRS/" yid/yid > yid/yid2; mv yid/yid2 yid/yid

--- a/scripts/pickle/pickle_treebanks.py
+++ b/scripts/pickle/pickle_treebanks.py
@@ -28,6 +28,8 @@ if __name__ == "__main__":
             )
 
             print(lang, len(treebank))
+            if len(treebank)==0:
+                continue
 
             if remove_typo:
                 pickle_path = os.path.join(resource_dir, "ud/ud_pickles")

--- a/src/multiblimp/languages.py
+++ b/src/multiblimp/languages.py
@@ -83,7 +83,7 @@ udlang2treebanks = {
     "Vietnamese": ["VTB"],
     "Hebrew": ["HTB"],
     "Latvian": ["LVTB"],
-    "German": ["GSD", "PUD"],
+    "German": ["GSD", "PUD", "HDT"],
     "Czech": ["CAC", "CLTT", "FicTree", "PDT", "PUD"],
     "Russian": ["GSD", "PUD", "SynTagRus", "Taiga"],
     "Slovenian": ["SSJ"],

--- a/src/multiblimp/pipeline.py
+++ b/src/multiblimp/pipeline.py
@@ -320,6 +320,7 @@ class Pipeline:
 
         remove_diacritics = lang in remove_diacritics_langs
         remove_multiples = lang in remove_multiples_langs
+        print(unimorph_args)
 
         inflector = UnimorphInflector(
             langcode,

--- a/src/multiblimp/pipeline.py
+++ b/src/multiblimp/pipeline.py
@@ -320,7 +320,6 @@ class Pipeline:
 
         remove_diacritics = lang in remove_diacritics_langs
         remove_multiples = lang in remove_multiples_langs
-        print(unimorph_args)
 
         inflector = UnimorphInflector(
             langcode,

--- a/src/multiblimp/treebank.py
+++ b/src/multiblimp/treebank.py
@@ -160,7 +160,7 @@ class Treebank:
         treebank_glob = os.path.join(resource_dir, treebank_glob)
         treebank_paths = glob(treebank_glob)
 
-        skip_flagged = flag_treebanks("sign language") # exclude sign languages
+        skip_flagged = flag_treebanks("sign language")[lang] # exclude sign languages
         treebank_paths = [p for p in treebank_paths if p.split("/")[-2].split("-")[-1] not in skip_flagged]
         selected_treebanks = udlang2treebanks.get(lang)
         if use_selected_treebanks and selected_treebanks is not None:

--- a/src/multiblimp/treebank.py
+++ b/src/multiblimp/treebank.py
@@ -48,6 +48,90 @@ def tree_is_malformed(tree):
     return False
 
 
+def flag_treebanks(flag_type: str) -> dict[str, list[str]]:
+    """
+    Scrape UD and flag treebanks matching a given category.
+
+    Args:
+        flag_type: Either "words removed" (treebanks where the underlying
+            text has been removed, detected via a data-hint marker on the
+            treebank header itself) or "sign language" (treebanks whose
+            language is a sign language, detected via the "Sign Language"
+            text on the parent language header, since individual sign
+            language treebank rows carry no distinguishing marker of
+            their own).
+
+    Returns:
+        Dict mapping language_name -> [treebank_names]
+    """
+    flag_type = flag_type.strip().lower()
+    if flag_type not in ("words removed", "sign language"):
+        raise ValueError(
+            f'flag_type must be "words removed" or "sign language", got {flag_type!r}'
+        )
+
+    fp = urllib.request.urlopen("https://universaldependencies.org")
+    html_str = fp.read().decode("utf8")
+    fp.close()
+
+    soup = BeautifulSoup(html_str, features="html.parser")
+    results = {}
+
+    def name_of(header) -> str:
+        try:
+            return header.select_one("span.doublewidespan").get_text(strip=True)
+        except AttributeError:
+            return "UNKNOWN"
+
+    if flag_type == "words removed":
+        marker = 'span[data-hint="Underlying text not included"]'
+
+        for treebank_header in soup.select("div.ui-accordion-header"):
+            if treebank_header.select_one("span.flagspan img") is not None:
+                continue  # skip language-level headers
+            if treebank_header.select_one(marker) is None:
+                continue
+
+            try:
+                lang_header = (
+                    treebank_header
+                    .find_parent("div", class_="ui-accordion-content")
+                    .find_previous_sibling("div", class_="ui-accordion-header")
+                )
+                language_name = name_of(lang_header)
+            except AttributeError:
+                language_name = None
+
+            results.setdefault(language_name, []).append(name_of(treebank_header))
+
+    elif flag_type=="sign language":  # "sign language"
+        for lang_header in soup.select("div.ui-accordion-header"):
+            if lang_header.select_one("span.flagspan img") is None:
+                continue  # skip treebank-level headers
+
+            is_sign_language = any(
+                span.get_text(strip=True) == "Sign Language"
+                for span in lang_header.select("span.triplewidespan")
+            )
+            if not is_sign_language:
+                continue
+
+            language_name = name_of(lang_header).replace(" Sign Language", "")
+
+            try:
+                treebank_headers = lang_header.find_next_sibling(
+                    "div", class_="ui-accordion-content"
+                ).select("div.ui-accordion-header")
+            except AttributeError:
+                treebank_headers = []
+
+            results.setdefault(language_name, []).extend(
+                name_of(tb) for tb in treebank_headers
+            )
+
+    return results
+
+
 class Treebank:
     def __new__(
         cls,
@@ -76,6 +160,8 @@ class Treebank:
         treebank_glob = os.path.join(resource_dir, treebank_glob)
         treebank_paths = glob(treebank_glob)
 
+        skip_flagged = flag_treebanks("sign language") # exclude sign languages
+        treebank_paths = [p for p in treebank_paths if p.split("/")[-2].split("-")[-1] not in skip_flagged]
         selected_treebanks = udlang2treebanks.get(lang)
         if use_selected_treebanks and selected_treebanks is not None:
             selected_paths = []

--- a/src/multiblimp/treebank.py
+++ b/src/multiblimp/treebank.py
@@ -2,11 +2,13 @@ import os
 import pickle
 import re
 from glob import glob
+import urllib.request
 
 from arabic2latin import arabic_to_latin
 from conllu import parse_incr
 from indic_transliteration.sanscript import IAST, DEVANAGARI, transliterate
 from unidecode import unidecode
+from bs4 import BeautifulSoup
 
 from .config import UD_PATH
 from .languages import udlang2treebanks, convert_arabic_to_latin_langs
@@ -160,8 +162,8 @@ class Treebank:
         treebank_glob = os.path.join(resource_dir, treebank_glob)
         treebank_paths = glob(treebank_glob)
 
-        skip_flagged = flag_treebanks("sign language")[lang] # exclude sign languages
-        treebank_paths = [p for p in treebank_paths if p.split("/")[-2].split("-")[-1] not in skip_flagged]
+        skip_flagged = flag_treebanks("sign language").get((lang if not "_" in lang else lang.split("_")[0]), [])
+        treebank_paths = [p for p in treebank_paths if p.split("/")[-2].split("-")[-1].lower() not in skip_flagged]
         selected_treebanks = udlang2treebanks.get(lang)
         if use_selected_treebanks and selected_treebanks is not None:
             selected_paths = []

--- a/src/word_order/decision_tree.py
+++ b/src/word_order/decision_tree.py
@@ -18,7 +18,7 @@ from .utils import get_all_orders
 
 
 RND = 42
-OMIT_FEATURES = ["subject_idx", "object_idx", "verb_idx"]
+OMIT_FEATURES = ["subject_idx", "object_idx", "verb_idx"] # TODO should be passed via pipeline to fit_dt kwarg omit_feats
 
 
 def fit_dt(
@@ -48,6 +48,7 @@ def fit_dt(
     )
     omit_feats.update({col for col in full_df.columns if "idx" in col})
     omit_feats.update({col for col in full_df.columns if "_dir" in col})
+    omit_feats.update({col for col in full_df.columns if "agreement" in col and not predictor_var in col})
 
     sub_condition_on = list(set(full_df.columns) - omit_feats - {predictor_var})
 

--- a/src/word_order/html/html_deprel.py
+++ b/src/word_order/html/html_deprel.py
@@ -1,4 +1,5 @@
-def create_html(rows_six, rows_binary, plot_data_six_json, plot_data_binary_json):
+def create_html(rows_six, rows_binary, plot_data_six_json, plot_data_binary_json,
+                trivial_note=""):
     return f"""<!DOCTYPE html>
     <html lang="en">
     <head>
@@ -182,6 +183,15 @@ def create_html(rows_six, rows_binary, plot_data_six_json, plot_data_binary_json
                 border-radius: 8px;
                 background: white;
             }}
+            .trivial-note {{
+                font-size: 0.85rem;
+                color: #78716c;
+                margin-bottom: 1rem;
+                padding: 0.6rem 0.875rem;
+                background: #fafaf9;
+                border: 1px solid var(--border);
+                border-radius: 6px;
+            }}
         </style>
     </head>
     <body>
@@ -207,6 +217,8 @@ def create_html(rows_six, rows_binary, plot_data_six_json, plot_data_binary_json
             </div>
 
             <div id="scatterPlot"></div>
+
+            {trivial_note}
 
             <table id="dataTable">
                 <thead>
@@ -284,7 +296,7 @@ def create_html(rows_six, rows_binary, plot_data_six_json, plot_data_binary_json
                         sizemode: 'area',
                         sizeref: 2 * Math.max(...data.map(d => d.n_items)) / (40 ** 2),
                         sizemin: 4,
-                        color: '#2563eb',
+                        color: data.map(d => d.color),
                         opacity: 0.6,
                         line: {{
                             color: '#1e40af',

--- a/src/word_order/html/html_overview.py
+++ b/src/word_order/html/html_overview.py
@@ -189,10 +189,13 @@ def create_html(panels_html, all_data_json):
                     sizemode: 'area',
                     sizeref: 2 * Math.max(...points.map(d => d.n_items)) / (20 ** 2),
                     sizemin: 3,
-                    color: '#2563eb',
+                    color: points.map(d => d.color ?? '#2563eb'),
                     opacity: 0.75,
-                    line: {{ color: '#1e40af', width: 0.5 }}
-                }},
+                    line: {{ 
+                        color: points.map(d => d.color ?? '#2563eb'),
+                        width: 0.5 
+                        }}               
+                     }},
                 showlegend: false,
             }};
 

--- a/src/word_order/html/html_tree.py
+++ b/src/word_order/html/html_tree.py
@@ -581,7 +581,7 @@ def create_html(meta, node_samples, node_data, hex_colors, classes, div_id):
         max-width: 150px;
       }}
 
-       .node-table td:has(details[open]) {{
+      .node-table td:has(details[open]) {{
         white-space: normal;
         overflow: visible;
         max-width: none;

--- a/src/word_order/html/html_tree.py
+++ b/src/word_order/html/html_tree.py
@@ -938,10 +938,13 @@ def create_html(meta, node_samples, node_data, hex_colors, classes, div_id):
           html += "<tr>";
           cols.forEach(c => {{
             const cls = c === "sen_str" ? "col-sen_str" : "col-other";
-            const val = r[c] == null ? "" : String(r[c]).split(",").join("<br>");
-            const content = c.endsWith("_features")
-              ? "<details><summary>features...</summary>" + val + "</details>"
-              : val;
+            const raw = r[c] == null ? "" : String(r[c]);
+            let content;
+            if (c.endsWith("_features")) {{
+              content = "<details><summary>features...</summary>" + raw.split(",").join("<br>") + "</details>";
+            }} else {{
+              content = raw;
+            }}
             html += "<td class='" + cls + "'>" + content + "</td>";
           }});
           html += "</tr>";

--- a/src/word_order/process_treebank.py
+++ b/src/word_order/process_treebank.py
@@ -2,6 +2,7 @@ import sys
 import ast
 import os
 import random
+import re
 
 from collections import defaultdict, Counter
 
@@ -105,18 +106,29 @@ def extract_node_features(
     This ensures consistent feature extraction across all node types.
     """
     features = {}
+    morph_feats = dict()
 
     # Basic node features
     features[f"{prefix}_deprel"] = node["deprel"]
     features[f"{prefix}_pos"] = node["upos"]
-    features[f"{prefix}_form"] = node["form"]
+    features[f"{prefix}_form"] = node["form"].lower() if node["upos"]!="PROPN" else node["form"]
     features[f"{prefix}_lemma"] = node["lemma"]
     features[f"{prefix}_idx"] = node["id"]
 
     # Morphological features
     for feat in all_feats:
         features[f"{prefix}_{feat}"] = (node["feats"] or {}).get(feat)
+        if (node["feats"] or {}).get(feat, None):
+            morph_feats[feat] = node["feats"].get(feat, None)
 
+    # Further optional filters for head from PredictionTarget; filter is (lamnda x: condition)
+    if prefix=="head" and target.head_feats is not None:
+        if not all(
+            [val_filter(features.get(f"{prefix}_{feat}", None)) 
+             for feat, val_filter in target.head_feats.items()]
+             ):
+            return None # item does not fulfil PredictionTarget feature filters, drop instance
+    
     # Features about this node's relationship to its head
     if node["head"] != 0:
         head = tree[node["head"] - 1]
@@ -275,7 +287,8 @@ def extract_sen_features(tree):
     return feature2val
 
 
-def extract_instances(tree, tree_idx, target: PredictionTarget, tree_metadata):
+def extract_instances(tree, tree_idx, target: PredictionTarget, tree_metadata,
+                      predictor_var):
     """
     Extract training instances from a tree based on the prediction target.
 
@@ -381,6 +394,9 @@ def extract_instances(tree, tree_idx, target: PredictionTarget, tree_metadata):
             target,
         )
         instance.update(head_features)
+        
+        if head_features == None: # item failed PredictionTarget filters
+            continue
 
         # Extract features for each child type; use deprel as prefix (e.g. "nsubj_pos", "amod_pos")
         for deprel in target.child_deprels:
@@ -406,6 +422,29 @@ def extract_instances(tree, tree_idx, target: PredictionTarget, tree_metadata):
             )
             instance.update(child_features)
 
+            # add SV agreement variable for predictor_var (e.g. "head_nsubj_Number_agreement")
+            # 1. is feature annotated on head & target child?, 2. is value the same? -> TRUE else False
+            if predictor_var and "agreement" in predictor_var:
+                target_feature = re.match(r".*_([A-Z][a-z]+)_.*", predictor_var).group(1)
+                head_val = head_features.get(f"head_{target_feature}", None)
+                child_val = child_features.get(f"{deprel}_{target_feature}", None)
+                if head_val == child_val:
+                    if head_val!=None:
+                        agreement_label = "Yes" # both set and agreeing
+                    else:
+                        agreement_label = "--" # both undefined
+                elif head_val!=None:
+                    if child_val!=None:
+                        agreement_label = "No" # both set but disagreement
+                    else:
+                        agreement_label = "+-" # child feat not set
+                elif head_val==None:
+                    agreement_label = "+-" # head feat notset
+                else:
+                    raise ValueError("Value combination inadmissable") # should not occur
+
+                instance[f"head_{deprel}_{target_feature}_agreement"] = agreement_label
+
         # Add sentence-level features
         instance.update(sen_features)
 
@@ -427,7 +466,7 @@ def extract_instances(tree, tree_idx, target: PredictionTarget, tree_metadata):
     return instances
 
 
-def extract_features(treebank, target: PredictionTarget):
+def extract_features(treebank, target: PredictionTarget, predictor_var):
     """
     Extract features from treebank based on prediction target.
 
@@ -444,7 +483,7 @@ def extract_features(treebank, target: PredictionTarget):
     all_instances = []
 
     for tree_idx, tree in tqdm(enumerate(treebank), total=len(treebank)):
-        instances = extract_instances(tree, tree_idx, target, tree_metadata)
+        instances = extract_instances(tree, tree_idx, target, tree_metadata, predictor_var)
         all_instances.extend(instances)
 
         if len(instances) > 0 and len(instances) % 100 == 0:
@@ -461,6 +500,7 @@ def create_word_order_df(
     save_to: str | None = None,
     max_treebank_len: int | None = None,
     drop_singleton_columns: bool = False,
+    predictor_var = None
 ) -> pd.DataFrame:
     """
     Create a DataFrame with word order features for a given language and prediction target.
@@ -498,7 +538,7 @@ def create_word_order_df(
         assert lang is not None
         treebank = load_treebank(lang, resource_dir, max_treebank_len=max_treebank_len)
 
-    all_instances = extract_features(treebank, target)
+    all_instances = extract_features(treebank, target, predictor_var)
     df = pd.DataFrame(all_instances)
 
     if drop_singleton_columns and len(df) > 0:

--- a/src/word_order/process_treebank.py
+++ b/src/word_order/process_treebank.py
@@ -543,6 +543,7 @@ def create_word_order_df(
 
     if drop_singleton_columns and len(df) > 0:
         always_keep = {"deprel_order", "sen", "treebank", "sent_id", "tree_idx"}
+        always_keep.update(set([col for col in df.columns if col.endswith("_idx")]))
         cols_to_check = df.columns.difference(list(always_keep))
         keep = df[cols_to_check].nunique() > 1
         kept_always = [c for c in always_keep if c in df.columns]

--- a/src/word_order/viz_deprel.py
+++ b/src/word_order/viz_deprel.py
@@ -3,6 +3,7 @@ from glob import glob
 from pathlib import Path
 from urllib.parse import quote
 from typing import Dict, Tuple
+import re
 
 import joblib
 import pandas as pd
@@ -48,6 +49,7 @@ def calculate_metrics(
         reduced_ent = calculate_tree_entropy(
             dt, df, target_col, binary=binary_entropy, smoothing=smoothing
         )
+
         delta_ent = base_ent - reduced_ent
 
         # Calculate accuracy on full training data
@@ -82,17 +84,19 @@ def calculate_metrics(
 
     return pd.DataFrame(metrics).sort_values("language")
 
+
 def scatter_color(metrics_row, language_data, target_col, exclude_labels=None):
-    """Yellow if all labels in , blue otherwise."""
+    """Yellow if all labels are in exclude_labels, blue otherwise."""
     if exclude_labels:
         lang_name = metrics_row["language"]
         if lang_name not in language_data:
             return "#2563eb"
         _, df = language_data[lang_name]
         labels = set(df[target_col].unique())
-        if labels <= {"--", "+-"}:
+        if labels <= set(exclude_labels):
             return "#e5c64d"
     return "#2563eb"
+
 
 def extract_trivial_label(html_path: Path) -> str | None:
     """Extract the sole label from a placeholder HTML file, or None if it's a real tree page."""
@@ -102,13 +106,15 @@ def extract_trivial_label(html_path: Path) -> str | None:
         return match.group(1).strip()
     return None
 
+
 def generate_html_deprel_index(
     data_dir: str,
     html_directory: str,
     language_data: Dict[str, Tuple[Pipeline, pd.DataFrame]] | None = None,
     target_col: str = "deprel_order",
     smoothing: float = 0.5,
-    exclude_labels=None,
+    exclude_labels: set | None = None,
+    include_trivial_labels: set | None = None,
 ) -> None:
     """Generate interactive overview page with metrics and language links.
 
@@ -117,15 +123,24 @@ def generate_html_deprel_index(
         html_directory: Directory to save the index.html file
         target_col: Column name containing word order labels
         smoothing: Smoothing factor for entropy calculation
+        exclude_labels: Labels that, when they are the only labels present, mark a
+            language as uninformative and cause it to be coloured yellow and omitted
+            from the table (e.g. {"--", "+-"}).
+        include_trivial_labels: Trivial labels that are still linguistically interesting
+            and should be kept in the table/scatter plot with a green marker instead of
+            being omitted (e.g. {"Yes"}).
     """
     html_directory = Path(html_directory)
+    include_trivial_labels = include_trivial_labels or set()
 
+    # Detect trivial langs from placeholder HTML files — keys are stem strings
     trivial_langs = {}
     for html_file in html_directory.glob("*.html"):
-        if not html_file.name.lower() == "index.html":
-            label = extract_trivial_label(html_file)
-            if label is not None:
-                trivial_langs[html_file.stem] = label
+        if html_file.name.lower() == "index.html":
+            continue
+        label = extract_trivial_label(html_file)
+        if label is not None:
+            trivial_langs[html_file.stem] = label  # ← stem string, not Path
 
     if language_data is None:
         language_data = {}
@@ -147,13 +162,46 @@ def generate_html_deprel_index(
         language_data, target_col, binary_entropy=True, smoothing=smoothing
     )
 
+    # Pick up any trivial langs not yet covered by placeholder files
     for l in metrics_six[metrics_six["base_entropy"] == 0.0]["language"]:
-        trivial_langs[l] =set(language_data[l][target_col].values)[0] # if placeholders dont exist yet
+        trivial_langs[l] = set(language_data[l][target_col].values)[0]
 
-    metrics_six    = metrics_six[~metrics_six["language"].isin(trivial_langs.keys())]
-    metrics_binary = metrics_binary[~metrics_binary["language"].isin(trivial_langs.keys())]
+    # Split trivial langs: include_trivial_labels go back into the main table/plot
+    include_trivial_langs = {k: v for k, v in trivial_langs.items() if v in include_trivial_labels}
+    omit_langs            = {k: v for k, v in trivial_langs.items() if v not in include_trivial_labels}
 
-    # Find corresponding HTML files
+    # Remove omitted langs from metrics; include_trivial_langs are re-added below
+    metrics_six    = metrics_six[~metrics_six["language"].isin(omit_langs.keys())]
+    metrics_binary = metrics_binary[~metrics_binary["language"].isin(omit_langs.keys())]
+    # Also drop include_trivial_langs that were in language_data (they have no tree)
+    metrics_six    = metrics_six[~metrics_six["language"].isin(include_trivial_langs.keys())]
+    metrics_binary = metrics_binary[~metrics_binary["language"].isin(include_trivial_langs.keys())]
+
+    # Add include_trivial_langs back as synthetic rows
+    if include_trivial_langs:
+        trivial_rows = []
+        for lang, label in include_trivial_langs.items():
+            if lang in language_data:
+                n_items = len(language_data[lang][1])
+            else:
+                csv_fn = os.path.join(data_dir, lang + ".csv")
+                n_items = len(pd.read_csv(csv_fn)) if os.path.exists(csv_fn) else 0
+            trivial_rows.append({
+                "language": lang,
+                "base_entropy": 0.0,
+                "reduced_entropy": 0.0,
+                "delta_entropy": 0.0,
+                "accuracy": 1.0,
+                "n_items": n_items,
+                "n_flexible": 0,
+                "n_fully_flexible": 0,
+                "total_pairs": 0,
+            })
+        trivial_df = pd.DataFrame(trivial_rows)
+        metrics_six    = pd.concat([metrics_six,    trivial_df]).sort_values("language").reset_index(drop=True)
+        metrics_binary = pd.concat([metrics_binary, trivial_df]).sort_values("language").reset_index(drop=True)
+
+    # Find corresponding HTML files — stem string -> Path
     html_files = {
         f.stem: f
         for f in html_directory.glob("*.html")
@@ -161,18 +209,28 @@ def generate_html_deprel_index(
     }
     deprel = html_directory.name
 
+    # Build color lookup before generating rows
+    lang_colors = {}
+    for _, row in metrics_six.iterrows():
+        lang_name = row["language"].replace("_", " ")
+        if row["language"] in include_trivial_langs:
+            lang_colors[lang_name] = "#31cb9f"  # green — matches palette_map "Yes"
+        else:
+            lang_colors[lang_name] = scatter_color(
+                row, language_data, target_col, exclude_labels=exclude_labels
+            )
+
     # Generate table rows for both entropy types
     def generate_rows(metrics_df, lang_colors):
         rows = []
         for _, row in metrics_df.iterrows():
             lang_name = row["language"].replace("_", " ")
-            lang_file = html_files.get(row["language"].replace(" ", "_"))
-            color = lang_colors.get(lang_name, "#2563eb")          # ← was "#1c1917"
+            lang_file = html_files.get(row["language"])  # ← stem matches directly
+            color = lang_colors.get(lang_name, "#2563eb")
             name_style = f' style="color:{color};font-weight:600;"' if color != "#2563eb" else ""
 
             if lang_file:
                 lang_link = (
-                    f'<a href="/multiblimp/{deprel}/{quote(lang_file.stem)}">{lang_name}</a>'
                     f'<a href="/multiblimp/{deprel}/{quote(lang_file.stem)}"{name_style}>{lang_name}</a>'
                 )
             else:
@@ -195,11 +253,7 @@ def generate_html_deprel_index(
             )
         return "".join(rows)
 
-    lang_colors = {
-        row["language"].replace("_", " "): scatter_color(row, language_data, target_col, exclude_labels=exclude_labels)
-        for _, row in metrics_six.iterrows()
-    }
-    rows_six = generate_rows(metrics_six, lang_colors)
+    rows_six    = generate_rows(metrics_six,    lang_colors)
     rows_binary = generate_rows(metrics_binary, lang_colors)
 
     # Generate scatter plot data for both entropy types
@@ -207,7 +261,7 @@ def generate_html_deprel_index(
         data = []
         for _, row in metrics_df.iterrows():
             lang_name = row["language"].replace("_", " ")
-            lang_file = html_files.get(row["language"].replace(" ", "_"))
+            lang_file = html_files.get(row["language"])  # ← stem matches directly
             url = f"/multiblimp/{deprel}/{quote(lang_file.stem)}" if lang_file else None
 
             data.append(
@@ -222,35 +276,63 @@ def generate_html_deprel_index(
             )
         return data
 
-    plot_data_six = generate_plot_data(metrics_six)
+    plot_data_six    = generate_plot_data(metrics_six)
     plot_data_binary = generate_plot_data(metrics_binary)
 
     # Convert to JSON for JavaScript
     import json
 
-    plot_data_six_json = json.dumps(plot_data_six)
+    plot_data_six_json    = json.dumps(plot_data_six)
     plot_data_binary_json = json.dumps(plot_data_binary)
 
-    html_content = create_html(rows_six, rows_binary, plot_data_six_json, plot_data_binary_json)
-    if trivial_langs:
+    # Build legend / notes
+    color_note_parts = [
+        '<p class="trivial-note">'
+        '<span style="display:inline-block;width:10px;height:10px;border-radius:50%;'
+        'background:#e5c64d;margin-right:6px;vertical-align:middle;"></span>'
+        'Languages shown in <strong>yellow</strong> only exhibit uninformative agreement '
+        '(labels <code>--</code> and <code>+-</code>) — no Yes/No contrast was observed.'
+    ]
+    if include_trivial_labels:
+        labels_str = ", ".join(f"<code>{l}</code>" for l in sorted(include_trivial_labels))
+        color_note_parts.append(
+            '<br>'
+            '<span style="display:inline-block;width:10px;height:10px;border-radius:50%;'
+            'background:#31cb9f;margin-right:6px;margin-top:6px;vertical-align:middle;"></span>'
+            f'Languages shown in <strong>green</strong> have categorical agreement throughout '
+            f'— all samples share the label {labels_str}.'
+        )
+    color_note_parts.append('</p>')
+    color_note = "".join(color_note_parts)
+
+    if omit_langs:
         skipped_links = []
-        for lang, pred_tag in sorted(trivial_langs.items()):
+        for lang, pred_tag in sorted(omit_langs.items()):
             lang_display = lang.replace("_", " ")
-            lang_file = html_files.get(lang.replace(" ", "_"))
+            lang_file = html_files.get(lang)  # ← stem matches directly
             if lang_file:
                 url = f"/multiblimp/{deprel}/{quote(lang_file.stem)}"
-                skipped_links.append(f'<a href="{url}">{lang_display}</a> ({pred_tag})')
+                skipped_links.append(
+                    f'<a href="{url}" style="color:#b893de;font-weight:600;">{lang_display}</a> ({pred_tag})'
+                )
             else:
-                skipped_links.append(f'{lang_display} ({pred_tag})')
+                skipped_links.append(
+                    f'<span style="color:#b893de;font-weight:600;">{lang_display}</span> ({pred_tag})'
+                )
 
         trivial_note = (
             f'<p class="trivial-note">The following languages were omitted because '
-            f'all samples share a single agreement label: {", ".join(skipped_links)}.</p>'
+            f'all samples share a single uninformative agreement label: {", ".join(skipped_links)}.</p>'
         )
     else:
         trivial_note = ""
 
-    html_content = create_html(rows_six, rows_binary, plot_data_six_json, plot_data_binary_json,
-                               trivial_note=trivial_note)
+    notes = color_note + trivial_note
+
+    html_content = create_html(
+        rows_six, rows_binary,
+        plot_data_six_json, plot_data_binary_json,
+        trivial_note=notes,
+    )
     output_path = html_directory / "index.html"
     output_path.write_text(html_content, encoding="utf-8")

--- a/src/word_order/viz_deprel.py
+++ b/src/word_order/viz_deprel.py
@@ -35,10 +35,12 @@ def calculate_metrics(
 
     for lang_name, (dt, df) in tqdm(language_data.items()):
         # ensure dtype matching of loaded data and classifier
-        cat_cols = [ col for name, _, cols in dt.named_steps["preprocessor"].transformers_ if name == "cat"
+        cat_cols = [col for name, _, cols in dt.named_steps["preprocessor"].transformers_ if name == "cat"
                     for col in cols if col in df.columns]
         num_cols = [col for name, _, cols in dt.named_steps["preprocessor"].transformers_ if name == "num"
                     for col in cols if col in df.columns]
+        df[cat_cols] = df[cat_cols].astype(str)
+        df[num_cols] = df[num_cols].apply(pd.to_numeric, errors='coerce').fillna(0)
         # Calculate entropies
         base_ent = calculate_base_entropy(
             df, target_col, binary=binary_entropy, smoothing=smoothing
@@ -80,6 +82,25 @@ def calculate_metrics(
 
     return pd.DataFrame(metrics).sort_values("language")
 
+def scatter_color(metrics_row, language_data, target_col, exclude_labels=None):
+    """Yellow if all labels in , blue otherwise."""
+    if exclude_labels:
+        lang_name = metrics_row["language"]
+        if lang_name not in language_data:
+            return "#2563eb"
+        _, df = language_data[lang_name]
+        labels = set(df[target_col].unique())
+        if labels <= {"--", "+-"}:
+            return "#e5c64d"
+    return "#2563eb"
+
+def extract_trivial_label(html_path: Path) -> str | None:
+    """Extract the sole label from a placeholder HTML file, or None if it's a real tree page."""
+    content = html_path.read_text(encoding="utf-8")
+    match = re.search(r'<div class="label">(.+?)</div>', content)
+    if match and "No decision tree to display" in content:
+        return match.group(1).strip()
+    return None
 
 def generate_html_deprel_index(
     data_dir: str,
@@ -87,6 +108,7 @@ def generate_html_deprel_index(
     language_data: Dict[str, Tuple[Pipeline, pd.DataFrame]] | None = None,
     target_col: str = "deprel_order",
     smoothing: float = 0.5,
+    exclude_labels=None,
 ) -> None:
     """Generate interactive overview page with metrics and language links.
 
@@ -98,11 +120,20 @@ def generate_html_deprel_index(
     """
     html_directory = Path(html_directory)
 
+    trivial_langs = {}
+    for html_file in html_directory.glob("*.html"):
+        if not html_file.name.lower() == "index.html":
+            label = extract_trivial_label(html_file)
+            if label is not None:
+                trivial_langs[html_file.stem] = label
+
     if language_data is None:
         language_data = {}
 
         for model_fn in tqdm(glob(os.path.join(data_dir, "*.joblib"))):
             lang_name = Path(model_fn).stem
+            if lang_name in trivial_langs:
+                continue
             csv_fn = os.path.join(data_dir, lang_name + ".csv")
             if not os.path.exists(csv_fn):
                 continue
@@ -116,6 +147,12 @@ def generate_html_deprel_index(
         language_data, target_col, binary_entropy=True, smoothing=smoothing
     )
 
+    for l in metrics_six[metrics_six["base_entropy"] == 0.0]["language"]:
+        trivial_langs[l] =set(language_data[l][target_col].values)[0] # if placeholders dont exist yet
+
+    metrics_six    = metrics_six[~metrics_six["language"].isin(trivial_langs.keys())]
+    metrics_binary = metrics_binary[~metrics_binary["language"].isin(trivial_langs.keys())]
+
     # Find corresponding HTML files
     html_files = {
         f.stem: f
@@ -125,18 +162,21 @@ def generate_html_deprel_index(
     deprel = html_directory.name
 
     # Generate table rows for both entropy types
-    def generate_rows(metrics_df):
+    def generate_rows(metrics_df, lang_colors):
         rows = []
         for _, row in metrics_df.iterrows():
             lang_name = row["language"].replace("_", " ")
             lang_file = html_files.get(row["language"].replace(" ", "_"))
+            color = lang_colors.get(lang_name, "#2563eb")          # ← was "#1c1917"
+            name_style = f' style="color:{color};font-weight:600;"' if color != "#2563eb" else ""
 
             if lang_file:
                 lang_link = (
                     f'<a href="/multiblimp/{deprel}/{quote(lang_file.stem)}">{lang_name}</a>'
+                    f'<a href="/multiblimp/{deprel}/{quote(lang_file.stem)}"{name_style}>{lang_name}</a>'
                 )
             else:
-                lang_link = lang_name
+                lang_link = f'<span{name_style}>{lang_name}</span>'
 
             rows.append(
                 f"""
@@ -155,8 +195,12 @@ def generate_html_deprel_index(
             )
         return "".join(rows)
 
-    rows_six = generate_rows(metrics_six)
-    rows_binary = generate_rows(metrics_binary)
+    lang_colors = {
+        row["language"].replace("_", " "): scatter_color(row, language_data, target_col, exclude_labels=exclude_labels)
+        for _, row in metrics_six.iterrows()
+    }
+    rows_six = generate_rows(metrics_six, lang_colors)
+    rows_binary = generate_rows(metrics_binary, lang_colors)
 
     # Generate scatter plot data for both entropy types
     def generate_plot_data(metrics_df):
@@ -173,6 +217,7 @@ def generate_html_deprel_index(
                     "reduced": row["reduced_entropy"],
                     "n_items": int(row["n_items"]),
                     "url": url,
+                    "color": lang_colors.get(lang_name, "#2563eb"),
                 }
             )
         return data
@@ -187,5 +232,25 @@ def generate_html_deprel_index(
     plot_data_binary_json = json.dumps(plot_data_binary)
 
     html_content = create_html(rows_six, rows_binary, plot_data_six_json, plot_data_binary_json)
+    if trivial_langs:
+        skipped_links = []
+        for lang, pred_tag in sorted(trivial_langs.items()):
+            lang_display = lang.replace("_", " ")
+            lang_file = html_files.get(lang.replace(" ", "_"))
+            if lang_file:
+                url = f"/multiblimp/{deprel}/{quote(lang_file.stem)}"
+                skipped_links.append(f'<a href="{url}">{lang_display}</a> ({pred_tag})')
+            else:
+                skipped_links.append(f'{lang_display} ({pred_tag})')
+
+        trivial_note = (
+            f'<p class="trivial-note">The following languages were omitted because '
+            f'all samples share a single agreement label: {", ".join(skipped_links)}.</p>'
+        )
+    else:
+        trivial_note = ""
+
+    html_content = create_html(rows_six, rows_binary, plot_data_six_json, plot_data_binary_json,
+                               trivial_note=trivial_note)
     output_path = html_directory / "index.html"
     output_path.write_text(html_content, encoding="utf-8")

--- a/src/word_order/viz_tree.py
+++ b/src/word_order/viz_tree.py
@@ -5,6 +5,7 @@ import numpy as np
 import plotly.graph_objects as go
 import scipy
 import seaborn as sns
+import pandas as pd
 
 from matplotlib.colors import to_hex
 
@@ -150,16 +151,7 @@ def get_samples(
     
     keep_columns = ["sen_str"]
     full_df["sen_str"] = [" ".join(sen) for sen in full_df["sen"]]
-
-    tb_links = list()
-    map_to_x = {i: x for i, x in enumerate([chr(i) for i in range(ord('A'), ord('Z')+1)])}
-    for i, row in full_df.iterrows():
-        base_query = f"<a href='https://universal.grew.fr/?corpus={row['treebank']}@2.18&request=pattern {{ meta.sent_id = \"{row['sent_id']}\" ;QUERYSLOT_PLACEHOLDER }}' target='_blank'>{row['treebank']}</a>"
-        tb_links.append(base_query.replace("QUERYSLOT_PLACEHOLDER", ";".join(
-            [f' {map_to_x[j]} [form="{form}"] '
-            for j, form in enumerate(dict(row[[x for x in full_df.columns if x.endswith("_form")]]).values())]
-            )))
-    full_df["treebank_link"] = tb_links
+    full_df["treebank_link"] = build_treebank_links(full_df)
 
     if show_features:
         feat_collect = {}
@@ -168,7 +160,7 @@ def get_samples(
             for label, val in row.items():
                 prefix, feature = label.split("_")
                 mf[f"{prefix}_features"] = mf.get(f"{prefix}_features", list())
-                mf[f"{prefix}_features"].append(f"{feature}={(str(val)[:-2] if ("Person" in label and str(val).endswith(".0")) else val)}")
+                mf[f"{prefix}_features"].append(f"{feature}={(str(val)[:-2] if str(val).endswith(".0") else val)}")            
             for k, v in mf.items():
                 feat_collect[k] = feat_collect.get(k, list())
                 feat_collect[k].append(v)
@@ -274,6 +266,169 @@ def interpolate_color(hex1, hex2, t):
 
     return f"#{r:02x}{g:02x}{b:02x}"
 
+def write_placeholder_html(out_file, predictor_var, label, meta=None, sample_rows=None):
+    meta_rows = ""
+    if meta:
+        for key, val in meta.items():
+            meta_rows += f'<div class="meta-row"><span class="meta-key">{key}</span><span class="meta-val">{val}</span></div>'
+
+    table_html = ""
+    if sample_rows:
+            cols = list(sample_rows[0].keys())
+            table_html += "<table class='ex-table'><thead><tr>"
+            for c in cols:
+                table_html += f"<th>{c}</th>"
+            table_html += "</tr></thead><tbody>"
+            for row in sample_rows:
+                table_html += "<tr>"
+                for c in cols:
+                    val = row[c]
+                    if val is None:
+                        content = ""
+                    elif c.endswith("_features"):
+                        # unpack list the same way as tree pages
+                        if isinstance(val, list):
+                            items = "<br>".join(v for v in val if not str(v).endswith("=nan"))
+                        else:
+                            # stored as string repr of list
+                            import ast
+                            try:
+                                items = "<br>".join(v for v in ast.literal_eval(str(val)) if not str(v).endswith("=nan"))
+                            except Exception:
+                                items = str(val)
+                        content = f"<details><summary>features...</summary>{items}</details>"
+                    else:
+                        content = str(val)
+                    table_html += f"<td>{content}</td>"
+                table_html += "</tr>"
+            table_html += "</tbody></table>"
+
+    html = f"""<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>No decision tree to display</title>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    body {{ font-family: "DM Sans", sans-serif; margin: 0; background: #f5f5f4; color: #1c1917; }}
+    .layout {{ display: flex; height: 100vh; }}
+    .sidebar {{
+        width: 260px; flex-shrink: 0; background: white;
+        border-right: 1px solid #e7e5e4; padding: 1.5rem; display: flex;
+        flex-direction: column; gap: 1rem;
+    }}
+    h2 {{ font-size: 1.1rem; margin: 0; }}
+    p  {{ color: #78716c; font-size: 0.875rem; margin: 0; line-height: 1.5; }}
+    .label {{ display: inline-block; padding: 0.3rem 0.9rem;
+              background: #f5f5f4; border-radius: 999px; font-weight: 600;
+              font-size: 1rem; border: 1px solid #e7e5e4; }}
+    .meta {{ font-size: 0.8rem; }}
+    .meta-row {{ display: flex; justify-content: space-between; padding: 0.2rem 0;
+                 border-bottom: 1px solid #e7e5e4; }}
+    .meta-key {{ color: #a8a29e; }}
+    .meta-val {{ font-family: "JetBrains Mono", monospace; color: #78716c; }}
+    .main {{ flex: 1; overflow-y: auto; padding: 1.5rem; }}
+    .main h3 {{ font-size: 0.8rem; font-weight: 600; text-transform: uppercase;
+                letter-spacing: 0.05em; color: #78716c; margin: 0 0 0.75rem; }}
+    .ex-table {{ border-collapse: collapse; width: 100%; font-size: 0.8rem;
+                 border: 1px solid #e7e5e4; border-radius: 8px; overflow: hidden; }}
+    .ex-table th {{ background: #fafaf9; color: #78716c; font-size: 0.7rem; font-weight: 600;
+                    text-transform: uppercase; letter-spacing: 0.04em; padding: 6px 10px;
+                    text-align: left; border-bottom: 1px solid #e7e5e4; white-space: nowrap; }}
+    .ex-table td {{ padding: 5px 10px; border-bottom: 1px solid #f0efee; vertical-align: top;
+                    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 200px; }}
+    .ex-table td:first-child {{ white-space: normal; word-break: break-word; max-width: none; }}
+    .ex-table tbody tr:hover td {{ background: #eff6ff; }}
+    .ex-table a {{ color: #2563eb; text-decoration: none; font-weight: 500; }}
+    .ex-table a:hover {{ text-decoration: underline; }}
+    .ex-table tbody tr:last-child td {{ border-bottom: none; }}
+  </style>
+</head>
+<body>
+  <div class="layout">
+    <div class="sidebar">
+      <div>
+        <h2>Single label</h2>
+        <p>All training samples for <b>{predictor_var}</b> share one agreement label — no decision tree was needed.</p>
+      </div>
+      <div class="label">{label}</div>
+      <div class="meta">{meta_rows}</div>
+    </div>
+    <div class="main">
+      <h3>Example items (sample of {len(sample_rows) if sample_rows else 0})</h3>
+      {table_html}
+    </div>
+  </div>
+</body>
+</html>"""
+
+    os.makedirs(os.path.dirname(out_file), exist_ok=True)
+    with open(out_file, "w", encoding="utf-8") as f:
+        f.write(html)
+    
+def has_word_forms(row, form_cols):
+    """True if at least one form column has a real word (not underscore or empty)."""
+    return any(str(row[c]).strip() not in ("_", "", "nan") for c in form_cols)
+
+def build_treebank_links(full_df: pd.DataFrame) -> list[str]:
+    """Build grew.fr query links for each row in full_df."""
+    map_to_x = {i: x for i, x in enumerate([chr(i) for i in range(ord('A'), ord('Z') + 1)])}
+    form_cols = [x for x in full_df.columns if x.endswith("_form")]
+    tb_links = []
+    for _, row in full_df.iterrows():
+        base_query = (
+            f"<a href='https://universal.grew.fr/?corpus={row['treebank']}@2.18"
+            f"&request=pattern {{ meta.sent_id = \"{row['sent_id']}\" ;QUERYSLOT_PLACEHOLDER }}'"
+            f" target='_blank'>{row['treebank']}</a>"
+        )
+        slot = ";".join(
+            f' {map_to_x[j]} [form="{form}"] '
+            for j, form in enumerate(dict(row[form_cols]).values())
+        )
+        tb_links.append(base_query.replace("QUERYSLOT_PLACEHOLDER", slot))
+    return tb_links
+
+def remove_censored(full_df):
+    form_cols = [x for x in full_df.columns if x.endswith("_form")]
+    return full_df[full_df.apply(lambda row: has_word_forms(row, form_cols), axis=1)]
+
+def build_placeholder_args(dt_df, full_df, predictor_var, meta=None, show_features=False):
+    """Compute all arguments needed for write_placeholder_html."""
+    sole_label = dt_df[predictor_var].iloc[0]
+
+    if meta is None:
+        meta = {}
+    meta["Training samples"] = f"{len(dt_df):,}"
+    meta["Predictor"] = predictor_var
+
+    full_df["sen_str"] = [" ".join(sen) for sen in full_df["sen"]]
+    full_df["treebank_link"] = build_treebank_links(full_df)
+
+    keep_columns = ["sen_str"]
+    if show_features:
+        feat_collect = {}
+        for i, row in full_df.filter(regex = r'^[a-z]+_[A-Z][a-z]+$', axis=1).iterrows():
+            mf = dict()
+            for label, val in row.items():
+                prefix, feature = label.split("_")
+                mf[f"{prefix}_features"] = mf.get(f"{prefix}_features", list())
+                mf[f"{prefix}_features"].append(f"{feature}={(str(val)[:-2] if str(val).endswith(".0") else val)}")
+            for k, v in mf.items():
+                feat_collect[k] = feat_collect.get(k, list())
+                feat_collect[k].append(v)
+
+        for k, v in feat_collect.items():
+            full_df[k] = v
+            keep_columns.extend([f"{k.split("_")[0]+"_form"}",  k ])
+    else:
+        keep_columns.extend([col for col in full_df if col.endswith("_form") ])
+
+    keep_columns.append("treebank_link")
+
+    sample_rows = full_df.sample(min(50, len(full_df)), random_state=42)[keep_columns].to_dict("records")
+
+    return sole_label, meta, sample_rows
+
 
 def tree2html(
     pipeline_model,
@@ -286,7 +441,9 @@ def tree2html(
     meta=None,
     only_show_real_orders=False,
     correlate_features=True,
-    show_features=False
+    show_features=False,
+    full_tree_html=True,
+    palette_map=None
 ):
     """
     pipeline_model:
@@ -307,7 +464,10 @@ def tree2html(
             }
         If not provided, these values are computed automatically where possible.
     """
-
+    if full_tree_html==False:       
+        write_placeholder_html(out_file, predictor_var, 
+                               *build_placeholder_args(dt_df, full_df, predictor_var, meta, show_features=show_features))
+        return
     prep = pipeline_model.named_steps["preprocessor"]
     clf = pipeline_model.named_steps["clf"]
 
@@ -358,11 +518,13 @@ def tree2html(
 
     # Expand label_distribution to full display_classes (missing classes get 0)
     label_distribution = []
+    label_distribution2 = dict()
     for dist in label_distribution_model:
         full_dist = []
-        for cls in classes:
+        for cls in sorted(classes):
             if cls in class2idx_model:
                 full_dist.append(dist[class2idx_model[cls]])
+                label_distribution2[cls] = dist[class2idx_model[cls]]
             else:
                 full_dist.append(0)
         label_distribution.append(full_dist)
@@ -413,9 +575,13 @@ def tree2html(
     else:
         correlated_features = {}
 
-    # Always generate palette across full SVO space so colours are stable
-    palette = sns.color_palette("husl", n_colors=max(n_classes, len(all_orders)))
-    hex_colors = [to_hex(c) for c in palette[:n_classes]]
+    if palette_map:
+        # Fix canonical order and colors from palette_map, regardless of what's in the data
+        classes = list(palette_map.keys())
+        hex_colors = list(palette_map.values())
+    else:
+        palette = sns.color_palette("husl", n_colors=max(n_classes, len(all_orders)))[:n_classes]
+        hex_colors = [to_hex(c) for c in palette]
 
     # Grey out classes with zero samples at the root (absent from this language)
     root_dist = label_distribution[0]
@@ -423,6 +589,23 @@ def tree2html(
         color if root_dist[idx] > 0 else "#d4d4d4"
         for idx, color in enumerate(hex_colors)
     ]
+    if not palette_map:
+        hex_colors = [
+            color if root_dist[idx] > 0 else "#d4d4d4"
+            for idx, color in enumerate(hex_colors)
+        ]
+
+    # Rebuild class2idx from the canonical classes list
+    class2idx = {c: idx for idx, c in enumerate(classes)}
+
+    # Rebuild label_distribution to match canonical classes order
+    label_distribution = []
+    for dist in label_distribution_model:
+        full_dist = [
+            dist[class2idx_model[cls]] if cls in class2idx_model else 0
+            for cls in classes
+        ]
+        label_distribution.append(full_dist)
 
     annotations = []
     node_data = {}

--- a/src/word_order/viz_tree.py
+++ b/src/word_order/viz_tree.py
@@ -160,7 +160,7 @@ def get_samples(
             for label, val in row.items():
                 prefix, feature = label.split("_")
                 mf[f"{prefix}_features"] = mf.get(f"{prefix}_features", list())
-                mf[f"{prefix}_features"].append(f"{feature}={(str(val)[:-2] if str(val).endswith(".0") else val)}")            
+                mf[f"{prefix}_features"].append(f"{feature}={(str(val)[:-2] if str(val).endswith(".0") else val)}")
             for k, v in mf.items():
                 feat_collect[k] = feat_collect.get(k, list())
                 feat_collect[k].append(v)
@@ -382,7 +382,7 @@ def build_treebank_links(full_df: pd.DataFrame) -> list[str]:
             f" target='_blank'>{row['treebank']}</a>"
         )
         slot = ";".join(
-            f' {map_to_x[j]} [form="{form if row[f"{label.split("_")[0]}_idx"]!=1 else form.capitalize()}"] '
+            f' {map_to_x[j]} [form="{form if row[f"{label.split("_")[0]}_idx"]!=1 else str(form).capitalize()}"] '
             for j, (label, form) in enumerate(dict(row[form_cols]).items())
         )
         tb_links.append(base_query.replace("QUERYSLOT_PLACEHOLDER", slot))
@@ -468,6 +468,7 @@ def tree2html(
         write_placeholder_html(out_file, predictor_var, 
                                *build_placeholder_args(dt_df, full_df, predictor_var, meta, show_features=show_features))
         return
+
     prep = pipeline_model.named_steps["preprocessor"]
     clf = pipeline_model.named_steps["clf"]
 
@@ -583,12 +584,8 @@ def tree2html(
         palette = sns.color_palette("husl", n_colors=max(n_classes, len(all_orders)))[:n_classes]
         hex_colors = [to_hex(c) for c in palette]
 
-    # Grey out classes with zero samples at the root (absent from this language)
+    # Grey out classes absent from this language (only for dynamic palette)
     root_dist = label_distribution[0]
-    hex_colors = [
-        color if root_dist[idx] > 0 else "#d4d4d4"
-        for idx, color in enumerate(hex_colors)
-    ]
     if not palette_map:
         hex_colors = [
             color if root_dist[idx] > 0 else "#d4d4d4"
@@ -664,10 +661,12 @@ def tree2html(
             # Leaf: include all classes with count >= 50% of the majority
             sorted_dist = sorted(zip(dist_i, classes), key=lambda x: x[0], reverse=True)
             top_cnt, top_cls = sorted_dist[0]
+            # print(sorted_dist)
             qualifying = [top_cls] + [
                 cls for cnt, cls in sorted_dist[1:] if cnt > 0 and cnt >= 0.5 * top_cnt
             ]
             qualifying = [str(x) for x in qualifying if not type(x)==str]
+            # if not all([type(x)==str for x in qualifying])
             leaf_label = f"<b>{' / '.join(qualifying)}</b>"
             label = (
                 f"{leaf_label}<br>"

--- a/src/word_order/viz_tree.py
+++ b/src/word_order/viz_tree.py
@@ -382,8 +382,8 @@ def build_treebank_links(full_df: pd.DataFrame) -> list[str]:
             f" target='_blank'>{row['treebank']}</a>"
         )
         slot = ";".join(
-            f' {map_to_x[j]} [form="{form}"] '
-            for j, form in enumerate(dict(row[form_cols]).values())
+            f' {map_to_x[j]} [form="{form if row[f"{label.split("_")[0]}_idx"]!=1 else form.capitalize()}"] '
+            for j, (label, form) in enumerate(dict(row[form_cols]).items())
         )
         tb_links.append(base_query.replace("QUERYSLOT_PLACEHOLDER", slot))
     return tb_links


### PR DESCRIPTION
viz: opt. set custom colours per prediction label, opt.: re-colour uninformative langauge data (for agreement: annotation underspecified)

placeholders: detect trivial language data (only one value across the prediction variable -> don't fit tree, write placeholder html, omit from scatter plot)

udpate unimorph changelog for  san/yid (NEUTT/PRES)

re added german HDT to inclusion list

exclude samples from html where all word form have been removed

exclude sign lanugages from data selection

lowercase word forms for word form based features/variables (except PROPN)

general prep for merging word order and sva dt branches to build UM2UD mapping on top